### PR TITLE
Add UTM parameters to replicate.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ Create and edit images using your voice.
 🍿 [Watch the demo video](https://www.youtube.com/watch?v=72mD_vkG9FU)
 
 This is a realtime demo of voice-powered function calling
-using [Cloudflare Workers](https://developers.cloudflare.com), [Replicate](https://replicate.com?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral), and the [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime).
+using [Cloudflare Workers](https://developers.cloudflare.com), [Replicate](https://replicate.com?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral), and the [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime).
 
-It generates images using [Flux Schnell](https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral) and edits them using [Flux Kontext Pro](https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral).
+It generates images using [Flux Schnell](https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral) and edits them using [Flux Kontext Pro](https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral).
 
-Created from this guide and template: https://replicate.com/docs/guides/openai-realtime?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral
+Created from this guide and template: https://replicate.com/docs/guides/openai-realtime?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral
 
 ## Prerequisites
 
 Here's what you'll need to build this project:
 
 - An [OpenAI account](https://platform.openai.com/signup). No special plan is required to use the Realtime API Beta.
-- A [Replicate account](https://replicate.com/?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral).
+- A [Replicate account](https://replicate.com/?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral).
 - [Node.js 20](https://nodejs.org/en/download/prebuilt-installer) or later.
 - [Git](https://chatgpt.com/share/673d65dc-8e50-8003-8ce2-4bc7053d0e3a) for cloning the project from 
 GitHub.
@@ -28,7 +28,7 @@ GitHub.
 
 ## Development
 
-- Create a Replicate API token at [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral)
+- Create a Replicate API token at [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral)
 - Create an OpenAI API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 
 Copy [.dev.vars.example](./.dev.vars.example) to `.dev.vars`:
@@ -67,7 +67,7 @@ npx wrangler secret put REPLICATE_API_TOKEN
 
 ## Replicate API Token
 
-When you first load the app, you will be prompted to enter your Replicate API token in a modal dialog. The token is stored in your browser's localStorage and used for all Replicate API requests. You can get a token from [Replicate's API tokens page](https://replicate.com/account/api-tokens?new-token-name=kontext-realtime&utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral).
+When you first load the app, you will be prompted to enter your Replicate API token in a modal dialog. The token is stored in your browser's localStorage and used for all Replicate API requests. You can get a token from [Replicate's API tokens page](https://replicate.com/account/api-tokens?new-token-name=kontext-realtime&utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral).
 
 You no longer need to set the `REPLICATE_API_TOKEN` environment variable or use `wrangler secret put` for this project.
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ Create and edit images using your voice.
 🍿 [Watch the demo video](https://www.youtube.com/watch?v=72mD_vkG9FU)
 
 This is a realtime demo of voice-powered function calling
-using [Cloudflare Workers](https://developers.cloudflare.com), [Replicate](https://replicate.com?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral), and the [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime).
+using [Cloudflare Workers](https://developers.cloudflare.com), [Replicate](https://replicate.com?utm_campaign=kontext-realtime&utm_source=project), and the [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime).
 
-It generates images using [Flux Schnell](https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral) and edits them using [Flux Kontext Pro](https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral).
+It generates images using [Flux Schnell](https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=project) and edits them using [Flux Kontext Pro](https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=project).
 
-Created from this guide and template: https://replicate.com/docs/guides/openai-realtime?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral
+Created from this guide and template: https://replicate.com/docs/guides/openai-realtime?utm_campaign=kontext-realtime&utm_source=project
 
 ## Prerequisites
 
 Here's what you'll need to build this project:
 
 - An [OpenAI account](https://platform.openai.com/signup). No special plan is required to use the Realtime API Beta.
-- A [Replicate account](https://replicate.com/?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral).
+- A [Replicate account](https://replicate.com/?utm_campaign=kontext-realtime&utm_source=project).
 - [Node.js 20](https://nodejs.org/en/download/prebuilt-installer) or later.
 - [Git](https://chatgpt.com/share/673d65dc-8e50-8003-8ce2-4bc7053d0e3a) for cloning the project from 
 GitHub.
@@ -28,7 +28,7 @@ GitHub.
 
 ## Development
 
-- Create a Replicate API token at [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral)
+- Create a Replicate API token at [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens?utm_campaign=kontext-realtime&utm_source=project)
 - Create an OpenAI API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 
 Copy [.dev.vars.example](./.dev.vars.example) to `.dev.vars`:
@@ -67,7 +67,7 @@ npx wrangler secret put REPLICATE_API_TOKEN
 
 ## Replicate API Token
 
-When you first load the app, you will be prompted to enter your Replicate API token in a modal dialog. The token is stored in your browser's localStorage and used for all Replicate API requests. You can get a token from [Replicate's API tokens page](https://replicate.com/account/api-tokens?new-token-name=kontext-realtime&utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral).
+When you first load the app, you will be prompted to enter your Replicate API token in a modal dialog. The token is stored in your browser's localStorage and used for all Replicate API requests. You can get a token from [Replicate's API tokens page](https://replicate.com/account/api-tokens?new-token-name=kontext-realtime&utm_campaign=kontext-realtime&utm_source=project).
 
 You no longer need to set the `REPLICATE_API_TOKEN` environment variable or use `wrangler secret put` for this project.
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ Create and edit images using your voice.
 🍿 [Watch the demo video](https://www.youtube.com/watch?v=72mD_vkG9FU)
 
 This is a realtime demo of voice-powered function calling
-using [Cloudflare Workers](https://developers.cloudflare.com), [Replicate](https://replicate.com), and the [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime).
+using [Cloudflare Workers](https://developers.cloudflare.com), [Replicate](https://replicate.com?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral), and the [OpenAI Realtime API](https://platform.openai.com/docs/api-reference/realtime).
 
-It generates images using [Flux Schnell](https://replicate.com/black-forest-labs/flux-schnell) and edits them using [Flux Kontext Pro](https://replicate.com/black-forest-labs/flux-kontext-pro).
+It generates images using [Flux Schnell](https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral) and edits them using [Flux Kontext Pro](https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral).
 
-Created from this guide and template: https://replicate.com/docs/guides/openai-realtime
+Created from this guide and template: https://replicate.com/docs/guides/openai-realtime?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral
 
 ## Prerequisites
 
 Here's what you'll need to build this project:
 
 - An [OpenAI account](https://platform.openai.com/signup). No special plan is required to use the Realtime API Beta.
-- A [Replicate account](https://replicate.com/).
+- A [Replicate account](https://replicate.com/?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral).
 - [Node.js 20](https://nodejs.org/en/download/prebuilt-installer) or later.
 - [Git](https://chatgpt.com/share/673d65dc-8e50-8003-8ce2-4bc7053d0e3a) for cloning the project from 
 GitHub.
@@ -28,7 +28,7 @@ GitHub.
 
 ## Development
 
-- Create a Replicate API token at [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens)
+- Create a Replicate API token at [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral)
 - Create an OpenAI API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 
 Copy [.dev.vars.example](./.dev.vars.example) to `.dev.vars`:
@@ -67,7 +67,7 @@ npx wrangler secret put REPLICATE_API_TOKEN
 
 ## Replicate API Token
 
-When you first load the app, you will be prompted to enter your Replicate API token in a modal dialog. The token is stored in your browser's localStorage and used for all Replicate API requests. You can get a token from [Replicate's API tokens page](https://replicate.com/account/api-tokens?new-token-name=kontext-realtime).
+When you first load the app, you will be prompted to enter your Replicate API token in a modal dialog. The token is stored in your browser's localStorage and used for all Replicate API requests. You can get a token from [Replicate's API tokens page](https://replicate.com/account/api-tokens?new-token-name=kontext-realtime&utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral).
 
 You no longer need to set the `REPLICATE_API_TOKEN` environment variable or use `wrangler secret put` for this project.
 

--- a/public/app.js
+++ b/public/app.js
@@ -510,7 +510,7 @@ const App = () => {
 						<footer className="py-8 opacity-70 mt-12">
 							<p>
 								This is a realtime demo of voice-powered function calling
-								using <a href="https://developers.cloudflare.com" className="underline">Cloudflare Workers</a>, <a href="https://replicate.com?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral" className="underline">Replicate</a>, and the <a href="https://platform.openai.com/docs/api-reference/realtime" className="underline">OpenAI Realtime API</a>. It generates images using <a href="https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral" className="underline">Flux Schnell</a> and edits them using <a href="https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral" className="underline">Flux Kontext Pro</a>.
+								using <a href="https://developers.cloudflare.com" className="underline">Cloudflare Workers</a>, <a href="https://replicate.com?utm_campaign=kontext-realtime&utm_source=project" className="underline">Replicate</a>, and the <a href="https://platform.openai.com/docs/api-reference/realtime" className="underline">OpenAI Realtime API</a>. It generates images using <a href="https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=project" className="underline">Flux Schnell</a> and edits them using <a href="https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=project" className="underline">Flux Kontext Pro</a>.
 							</p>
 							<p className="mt-4">
 								Check out the <a href="https://github.com/zeke/kontext-realtime/" className="underline">code</a>.
@@ -652,7 +652,7 @@ const TokenModal = ({ onSave }) => {
 					></iframe>
 				</div>
 				<p className="mb-2 text-stone-500">
-					To use this app, you need to <a href="https://replicate.com/account/api-tokens?new-token-name=kontext-realtime&utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral" target="_blank" rel="noopener noreferrer" className="underline">create a Replicate API token</a> and an <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener noreferrer" className="underline">OpenAI API key</a>.
+					To use this app, you need to <a href="https://replicate.com/account/api-tokens?new-token-name=kontext-realtime&utm_campaign=kontext-realtime&utm_source=project" target="_blank" rel="noopener noreferrer" className="underline">create a Replicate API token</a> and an <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener noreferrer" className="underline">OpenAI API key</a>.
 				</p>
 				<form onSubmit={e => { e.preventDefault(); handleSave(); }}>
 					<input

--- a/public/app.js
+++ b/public/app.js
@@ -510,7 +510,7 @@ const App = () => {
 						<footer className="py-8 opacity-70 mt-12">
 							<p>
 								This is a realtime demo of voice-powered function calling
-								using <a href="https://developers.cloudflare.com" className="underline">Cloudflare Workers</a>, <a href="https://replicate.com?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral" className="underline">Replicate</a>, and the <a href="https://platform.openai.com/docs/api-reference/realtime" className="underline">OpenAI Realtime API</a>. It generates images using <a href="https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral" className="underline">Flux Schnell</a> and edits them using <a href="https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral" className="underline">Flux Kontext Pro</a>.
+								using <a href="https://developers.cloudflare.com" className="underline">Cloudflare Workers</a>, <a href="https://replicate.com?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral" className="underline">Replicate</a>, and the <a href="https://platform.openai.com/docs/api-reference/realtime" className="underline">OpenAI Realtime API</a>. It generates images using <a href="https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral" className="underline">Flux Schnell</a> and edits them using <a href="https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral" className="underline">Flux Kontext Pro</a>.
 							</p>
 							<p className="mt-4">
 								Check out the <a href="https://github.com/zeke/kontext-realtime/" className="underline">code</a>.
@@ -652,7 +652,7 @@ const TokenModal = ({ onSave }) => {
 					></iframe>
 				</div>
 				<p className="mb-2 text-stone-500">
-					To use this app, you need to <a href="https://replicate.com/account/api-tokens?new-token-name=kontext-realtime" target="_blank" rel="noopener noreferrer" className="underline">create a Replicate API token</a> and an <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener noreferrer" className="underline">OpenAI API key</a>.
+					To use this app, you need to <a href="https://replicate.com/account/api-tokens?new-token-name=kontext-realtime&utm_campaign=kontext-realtime&utm_source=project&utm_medium=referral" target="_blank" rel="noopener noreferrer" className="underline">create a Replicate API token</a> and an <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener noreferrer" className="underline">OpenAI API key</a>.
 				</p>
 				<form onSubmit={e => { e.preventDefault(); handleSave(); }}>
 					<input

--- a/public/app.js
+++ b/public/app.js
@@ -510,7 +510,7 @@ const App = () => {
 						<footer className="py-8 opacity-70 mt-12">
 							<p>
 								This is a realtime demo of voice-powered function calling
-								using <a href="https://developers.cloudflare.com" className="underline">Cloudflare Workers</a>, <a href="https://replicate.com" className="underline">Replicate</a>, and the <a href="https://platform.openai.com/docs/api-reference/realtime" className="underline">OpenAI Realtime API</a>. It generates images using <a href="https://replicate.com/black-forest-labs/flux-schnell" className="underline">Flux Schnell</a> and edits them using <a href="https://replicate.com/black-forest-labs/flux-kontext-pro" className="underline">Flux Kontext Pro</a>.
+								using <a href="https://developers.cloudflare.com" className="underline">Cloudflare Workers</a>, <a href="https://replicate.com?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral" className="underline">Replicate</a>, and the <a href="https://platform.openai.com/docs/api-reference/realtime" className="underline">OpenAI Realtime API</a>. It generates images using <a href="https://replicate.com/black-forest-labs/flux-schnell?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral" className="underline">Flux Schnell</a> and edits them using <a href="https://replicate.com/black-forest-labs/flux-kontext-pro?utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral" className="underline">Flux Kontext Pro</a>.
 							</p>
 							<p className="mt-4">
 								Check out the <a href="https://github.com/zeke/kontext-realtime/" className="underline">code</a>.


### PR DESCRIPTION
Adds UTM parameters to all replicate.com links with campaign "kontext-realtime".

## Changes
- Added utm_campaign=kontext-realtime&utm_source=github&utm_medium=referral to all replicate.com links
- Updated 3 links in public/app.js 
- Updated 6 links in README.md

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)